### PR TITLE
Update to omniauth_openid_connect v0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-ultraauth (0.0.1)
-      omniauth_openid_connect (~> 0.2.4)
+      omniauth_openid_connect (~> 0.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,7 +36,7 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
-    omniauth_openid_connect (0.2.4)
+    omniauth_openid_connect (0.3.0)
       addressable (~> 2.5)
       omniauth (~> 1.3)
       openid_connect (~> 1.1)

--- a/omniauth-ultraauth.gemspec
+++ b/omniauth-ultraauth.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "omniauth_openid_connect", "~> 0.2.4"
+  spec.add_runtime_dependency "omniauth_openid_connect", "~> 0.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The omniauth_openid_connect has released a new 0.3.0 version. To this dependency update is required to make sure the latest version of OIDC implementation can be used.