### PR TITLE
Username should rely on the uid value

### DIFF
--- a/lib/omniauth/strategies/ultraauth.rb
+++ b/lib/omniauth/strategies/ultraauth.rb
@@ -18,7 +18,7 @@ module OmniAuth
 
       info do
         {
-          username: user_info.sub
+          username: uid
         }
       end
 


### PR DESCRIPTION
Fixes #4 

The `username` can rely on the `uid` method to change the used filed of the `userinfo` from the hardcoded `sub` by making use of the `uid_field` client option.